### PR TITLE
fix broken link in installation guide

### DIFF
--- a/Documentation/Guides/installation.md
+++ b/Documentation/Guides/installation.md
@@ -73,4 +73,4 @@ this situation).
 
 # What's next
 
-You can start reading [LIKO-12 "Getting Started" guide](./getting_started.md).
+You can start reading [LIKO-12 "Getting Started" guide](/Documentation/Guides/getting_started.md).

--- a/_navbar.md
+++ b/_navbar.md
@@ -1,12 +1,29 @@
 * [Home](/)
-* [Documentation](Documentation/)
-* [Getting Started](./Documentation/Guides/getting_started.md)
-* [Disks](https://liko-12.github.io/Disks/)
-* External Links
+* [Documentation](/Documentation/)
 
-  * [Itch.io](https://ramilego4game.itch.io/liko12)
-  * [Twitter](https://twitter.com/ramilego4game)
-  * [Discord](https://discord.gg/GDtHrsJ)
-  * [Tasks board](https://github.com/LIKO-12/LIKO-12/projects)
+* [Cheatsheets](/Documentation/Cheatsheets/)
+  * [GPU](/Documentation/Cheatsheets/GPU.md)
+  * [Other Peripherals](/Documentation/Cheatsheets/Other_Peripherals.md)
 
-* [FAQ](FAQ.md)
+* Guides
+  * [Filesystem](/Documentation/Guides/Filesystem.md)
+  * [Getting started](/Documentation/Guides/getting_started.md)
+  * [Keyboard shortcuts](/Documentation/Guides/Keyboard_shortcuts.md)
+  * [Using external code editor](/Documentation/Guides/Using_external_code_editor.md)
+  * [Manually creating .love file from .lk12](/Documentation/Guides/Manually_creating_.love_file_from_.lk12.md)
+
+* [Peripherals](/Documentation/Peripherals/)
+  * [GPU](/Documentation/Peripherals/GPU/)
+  * [CPU](/Documentation/Peripherals/CPU/)
+  * [RAM](/Documentation/Peripherals/RAM/)
+  * [FDD](/Documentation/Peripherals/FDD/)
+  * [HDD](/Documentation/Peripherals/HDD/)
+  * [WEB](/Documentation/Peripherals/WEB/)
+  * [BIOS](/Documentation/Peripherals/BIOS/)
+  * [Audio](/Documentation/Peripherals/Audio/)
+  * [Gamepad](/Documentation/Peripherals/Gamepad/)
+  * [Keyboard](/Documentation/Peripherals/Keyboard/)
+  * [TouchControls](/Documentation/Peripherals/TouchControls/)
+
+* DiskOS
+  * Games API


### PR DESCRIPTION
the link to getting started is broken at the end of the install guide
also the navbar switches around so I copied the guides one over

I didn't test this